### PR TITLE
Fix hero img on mobile safari, removed alert bar

### DIFF
--- a/src/components/alertbar.js
+++ b/src/components/alertbar.js
@@ -5,7 +5,7 @@ import isSupported from '../utils/supportedBrowser';
 const StyledAlert = styled.div`
     position: fixed;
     top: 0;
-    max-height: 25px;
+    max-height: 30px;
     width: 100%;
     font-family: "Calibre", "Inter", "San Francisco", "SF Pro Text", -apple-system, system-ui, sans-serif;
     font-size: 13px;

--- a/src/components/sections/hero.js
+++ b/src/components/sections/hero.js
@@ -162,6 +162,7 @@ const Hero = () => {
                                                     quality={95}
                                                     fomats={['AUTO', 'WEBP', 'AVIF']}
                                                     alt="Headshot"
+                                                    imgStyle={{borderRadius:'25px'}}
                                                 />
                                             </div>
                                         </StyledPic>

--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,7 @@ module.exports = {
             text: 'Jack Labbe'
         },
         section3: {
-            text: 'Student.'
+            text: 'Student, freelance software engineer.'
         },
         section4: {
             text: 'I have a passion for delivering high-quality products that create a meaningful and impactful experience.'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,6 @@ import Contact from '../components/sections/contact';
 const IndexPage = ({ location }) => {
     return (
         <div className="fillHeight">
-            <AlertBar />
             <Layout location={location}>
                 <Hero />
                 <About />


### PR DESCRIPTION
Hero image was not displaying correctly. Added imgStyle in Gatsby StaticImage to fix. Removed alert bar (not needed for now).